### PR TITLE
Installer Error

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -17,7 +17,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         // Ensure installation is not in progress
-        if ( ! strpos($_SERVER['REQUEST_URI'],'install') ) {
+        if ( ! strpos(url()->current(),'install') ) {
           DBConfigs::execute();
         }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -17,8 +17,8 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         // Ensure installation is not in progress
-        if ( ! strpos(url()->current(),'install') ) {
-          DBConfigs::execute();
+        if (!strpos(url()->current(), 'install')) {
+            DBConfigs::execute();
         }
 
         Setting::saving(function ($setting) {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -16,7 +16,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        DBConfigs::execute();
+        // Ensure installation is not in progress
+        if ( ! strpos($_SERVER['REQUEST_URI'],'install') ) {
+          DBConfigs::execute();
+        }
 
         Setting::saving(function ($setting) {
             Cache::forever($setting->key, $setting->value);


### PR DESCRIPTION
When performing an installation, they system errors because it cannot
find a database. Inside the appservcieprovider, have to comment out
DBConfig to get installer to work.